### PR TITLE
Make backend URL configurable via config.php

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,0 +1,5 @@
+<?php
+// Global configuration for the frontend
+// Use BACKEND_URL environment variable if set, otherwise default to localhost
+define('BACKEND_URL', getenv('BACKEND_URL') ?: 'http://localhost:8080');
+?>

--- a/public/src/views/chat.php
+++ b/public/src/views/chat.php
@@ -1,3 +1,4 @@
+<?php require_once "../../../config.php"; ?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -101,7 +102,7 @@
     }
 
     function loadProjects() {
-        fetch('http://localhost:8080/projects')
+        fetch('<?php echo BACKEND_URL; ?>/projects')
             .then(response => response.json())
             .then(data => {
                 const projectSelect = document.getElementById('project');
@@ -127,7 +128,7 @@
             appendMessage(userMessage, 'user-message');
             document.getElementById('user-input').value = '';
 
-            fetch('http://localhost:8080/ask', {
+            fetch('<?php echo BACKEND_URL; ?>/ask', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/public/src/views/manage.php
+++ b/public/src/views/manage.php
@@ -1,3 +1,4 @@
+<?php require_once "../../../config.php"; ?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -71,7 +72,7 @@
         <script>
             document.getElementById('fine-tune-button').addEventListener('click', function() {
                 const projectName = document.getElementById('generate-embeddings-projects').value;
-                fetch('http://localhost:8080/fine_tune', {
+                fetch('<?php echo BACKEND_URL; ?>/fine_tune', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -102,7 +103,7 @@
     <script>
         function createProject() {
             var projectName = document.getElementById("new-project").value;
-            fetch('http://localhost:8080/projects', {
+            fetch('<?php echo BACKEND_URL; ?>/projects', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -122,7 +123,7 @@
 
         function deleteProject() {
             var projectName = document.getElementById("existing-projects").value;
-            fetch('http://localhost:8080/projects', {
+            fetch('<?php echo BACKEND_URL; ?>/projects', {
                 method: 'DELETE',
                 headers: {
                     'Content-Type': 'application/json',
@@ -142,7 +143,7 @@
 
         function generateEmbeddings() {
             var projectName = document.getElementById("generate-embeddings-projects").value;
-            fetch(`http://localhost:8080/projects/${projectName}/generate_embeddings`, {
+            fetch(`<?php echo BACKEND_URL; ?>/projects/${projectName}/generate_embeddings`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -159,7 +160,7 @@
         }
 
         function deleteFile(projectName, fileName) {
-            fetch(`http://localhost:8080/projects/${projectName}/files`, {
+            fetch(`<?php echo BACKEND_URL; ?>/projects/${projectName}/files`, {
                 method: 'DELETE',
                 headers: {
                     'Content-Type': 'application/json',
@@ -178,7 +179,7 @@
         }
 
         function loadProjects() {
-            fetch('http://localhost:8080/projects')
+            fetch('<?php echo BACKEND_URL; ?>/projects')
             .then(response => response.json())
             .then(data => {
                 const projectSelect = document.getElementById('existing-projects');

--- a/public/src/views/upload.php
+++ b/public/src/views/upload.php
@@ -1,3 +1,4 @@
+<?php require_once "../../../config.php"; ?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -84,7 +85,7 @@
 <script>
     $(document).ready(function() {
         // Fetch and populate projects
-        $.get('http://localhost:8080/projects', function(data) {
+        $.get('<?php echo BACKEND_URL; ?>/projects', function(data) {
             var projectSelect = $('#project');
             projectSelect.empty();
             data.projects.forEach(function(project) {
@@ -110,7 +111,7 @@
             event.preventDefault();
             var formData = new FormData(this);
             $.ajax({
-                url: 'http://localhost:8080/upload',
+                url: '<?php echo BACKEND_URL; ?>/upload',
                 type: 'POST',
                 data: formData,
                 processData: false,


### PR DESCRIPTION
## Summary
- add new `config.php` to centralize `BACKEND_URL`
- reference `BACKEND_URL` in chat, upload and manage views

## Testing
- `php -l config.php`
- `php -l public/src/views/chat.php`
- `php -l public/src/views/upload.php`
- `php -l public/src/views/manage.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_686261a98a9083268fe56cb628dfe681