### PR TITLE
Add Docker setup

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY backend/ /app/
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8080
+CMD ["python", "app.py"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,13 @@
+FROM php:8.2-apache
+
+WORKDIR /var/www/html
+COPY . /var/www/html
+
+RUN apt-get update && \
+    apt-get install -y git unzip curl && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    composer install --no-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 80
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -123,13 +123,23 @@ Run the Flask app:
 ```bash
 python app.py
 ```
-The api is now available at http://localhost:5000/
+The api is now available at http://localhost:8080/
+
+## Docker Setup
+
+1. Ensure Docker and Docker Compose are installed.
+2. Build and start both services:
+   ```bash
+   docker compose up --build
+   ```
+3. The backend API will be available at [http://localhost:8080](http://localhost:8080)
+   and the PHP frontend at [http://localhost:8081](http://localhost:8081).
 
 
 ## Browse to your PHP Client installation
 or if you are using a pretty url then use the local domain template and browse to the correct project domain using your browser.
-```php
-https://localhost/DocuChat/
+```sh
+http://localhost:8081/
 ```
 
 ## Setup Simplified Steps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./backend/models:/app/models
+    command: python app.py
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "8081:80"
+    depends_on:
+      - backend


### PR DESCRIPTION
## Summary
- add Dockerfile for Python backend
- add Dockerfile for PHP frontend
- orchestrate services with docker-compose
- document Docker usage in README

## Testing
- `python -m py_compile backend/app.py`
- `python -m py_compile backend/download_models.py`
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686261ad9f7083268ebe4841051feee2