### PR TITLE
Add simple login system

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -20,6 +20,10 @@ app = Flask(__name__)
 app.secret_key = os.environ.get('SECRET_KEY', 'default_secret_key')
 CORS(app, resources={r"/*": {"origins": "*"}}, supports_credentials=True)
 
+# Simple credentials for optional API login
+USERNAME = os.environ.get('DOCUCHAT_USER', 'admin')
+PASSWORD = os.environ.get('DOCUCHAT_PASS', 'password')
+
 UPLOAD_FOLDER = 'static/uploads'
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 
@@ -203,6 +207,18 @@ def generate_embeddings_for_text(text):
         text_chunks.append(chunk_text)
 
     return chunk_embeddings, text_chunks
+
+# Optional API login endpoint
+@app.route('/login', methods=['POST'])
+def api_login():
+    data = request.json
+    if not data:
+        return jsonify({'status': 'failure'}), 400
+    username = data.get('username')
+    password = data.get('password')
+    if username == USERNAME and password == PASSWORD:
+        return jsonify({'status': 'success'})
+    return jsonify({'status': 'failure'}), 401
 
 @app.route('/projects/<project_name>/files', methods=['DELETE'])
 def delete_file_from_project(project_name):

--- a/public/src/views/auth.php
+++ b/public/src/views/auth.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    header('Location: login.php');
+    exit;
+}

--- a/public/src/views/authenticate.php
+++ b/public/src/views/authenticate.php
@@ -1,0 +1,18 @@
+<?php
+session_start();
+$user = getenv('DOCUCHAT_USER') ?: 'admin';
+$pass = getenv('DOCUCHAT_PASS') ?: 'password';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+    if ($username === $user && $password === $pass) {
+        $_SESSION['user'] = $username;
+        header('Location: index.php');
+        exit;
+    } else {
+        $_SESSION['error'] = 'Invalid credentials';
+        header('Location: login.php');
+        exit;
+    }
+}
+header('Location: login.php');

--- a/public/src/views/chat.php
+++ b/public/src/views/chat.php
@@ -1,3 +1,4 @@
+<?php require_once "auth.php"; ?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -63,6 +64,7 @@
 				<li class="nav-item">
 					<a class="nav-link" href="manage.php">Manage Projects</a>
 				</li>
+                                <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
 				
 			</ul>
 		</div>

--- a/public/src/views/index.php
+++ b/public/src/views/index.php
@@ -32,6 +32,7 @@
 									<li class="nav-item">
 										<a class="nav-link" href="manage.php">Manage Projects</a>
 									</li>
+                                        <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
 								
 								</ul>
             </div>

--- a/public/src/views/login.php
+++ b/public/src/views/login.php
@@ -1,0 +1,39 @@
+<?php
+session_start();
+if (isset($_SESSION['user'])) {
+    header('Location: index.php');
+    exit;
+}
+$error = $_SESSION['error'] ?? '';
+unset($_SESSION['error']);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login - DocuChat</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../../../public/css/styles.css">
+</head>
+<body class="d-flex align-items-center justify-content-center" style="height:100vh;">
+    <div class="container" style="max-width:400px;">
+        <h2 class="mb-4">Login</h2>
+        <?php if ($error): ?>
+            <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+        <?php endif; ?>
+        <form action="authenticate.php" method="post">
+            <div class="mb-3">
+                <label for="username" class="form-label">Username</label>
+                <input type="text" class="form-control" id="username" name="username" required>
+            </div>
+            <div class="mb-3">
+                <label for="password" class="form-label">Password</label>
+                <input type="password" class="form-control" id="password" name="password" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Login</button>
+        </form>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/public/src/views/logout.php
+++ b/public/src/views/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header('Location: login.php');
+exit;

--- a/public/src/views/manage.php
+++ b/public/src/views/manage.php
@@ -1,3 +1,4 @@
+<?php require_once "auth.php"; ?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -40,6 +41,7 @@
                     <li class="nav-item">
                         <a class="nav-link" href="manage.php">Manage Projects</a>
                     </li>
+                    <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
                 </ul>
             </div>
         </div>

--- a/public/src/views/upload.php
+++ b/public/src/views/upload.php
@@ -1,3 +1,4 @@
+<?php require_once "auth.php"; ?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -52,6 +53,7 @@
 				<li class="nav-item">
 					<a class="nav-link" href="manage.php">Manage Projects</a>
 				</li>
+                                <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
 			
 			</ul>
 		</div>


### PR DESCRIPTION
## Summary
- create session-based login pages
- enforce auth on chat, upload and management pages
- expose optional API login endpoint

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686261abd65c8326820b5e380ce93d8c