### PR TITLE
Add environment safety checks to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ Download the model:
 python download_models.py
 ```
 
+Before running the backend you must provide a secret key for Flask sessions. Set
+the `SECRET_KEY` environment variable and optionally `ALLOWED_ORIGINS` to limit
+CORS access.
+
+```bash
+export SECRET_KEY=your_secret_key
+# Optional: allow only specific origins
+export ALLOWED_ORIGINS="http://localhost:8080"
+```
+
 Run the Flask app:
 
 ```bash

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,9 +16,18 @@ from langdetect import detect
 # Set environment variable to handle OpenMP error
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 
+# Fetch the secret key from the environment and fail fast if it's missing
+SECRET_KEY = os.environ.get("SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("SECRET_KEY environment variable not set")
+
 app = Flask(__name__)
-app.secret_key = os.environ.get('SECRET_KEY', 'default_secret_key')
-CORS(app, resources={r"/*": {"origins": "*"}}, supports_credentials=True)
+app.secret_key = SECRET_KEY
+
+# Allow restricting CORS origins via the ALLOWED_ORIGINS environment variable
+_origins = os.environ.get("ALLOWED_ORIGINS", "*")
+origins = [o.strip() for o in _origins.split(",")] if _origins != "*" else "*"
+CORS(app, resources={r"/*": {"origins": origins}}, supports_credentials=True)
 
 UPLOAD_FOLDER = 'static/uploads'
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER


### PR DESCRIPTION
## Summary
- require `SECRET_KEY` for the Flask app
- optionally read `ALLOWED_ORIGINS` for CORS
- document the new environment variables

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686262a8aee883269753041b218cf366